### PR TITLE
Point to correct domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Python VirtualWire module for Raspberry Pi and 433MHz RF modules
 
 This code depends on **pigpio** library and can not be used without it.
 
-**Pigpio** library is available at [this site](http://abyz.co.uk/rpi/pigpio/)
+**Pigpio** library is available at [this site](http://abyz.me.uk/rpi/pigpio/)
 
-Follow [this](http://abyz.co.uk/rpi/pigpio/download.html) guide to install it on your platform.
+Follow [this](http://abyz.me.uk/rpi/pigpio/download.html) guide to install it on your platform.
 
 pigpio has to be running as a service. To start:
 `sudo /home/pi/PIGPIO/pigpiod`

--- a/piVirtualWire.py
+++ b/piVirtualWire.py
@@ -5,9 +5,9 @@
 
 """
 Original code made by joan http://93.93.128.176/forums/viewtopic.php?t=84596&p=598683
-http://abyz.co.uk/rpi/pigpio/code/vw.zip
+http://abyz.me.uk/rpi/pigpio/code/vw.zip
 
-Requires http://abyz.co.uk/rpi/pigpio/
+Requires http://abyz.me.uk/rpi/pigpio/
 
 """
 import time, pigpio


### PR DESCRIPTION
All http://abyz.co.uk/ links should point to correct http://abyz.me.uk site.